### PR TITLE
Don't return 400 errors for search/autocomplete

### DIFF
--- a/trackman/api/v1/track.py
+++ b/trackman/api/v1/track.py
@@ -188,7 +188,11 @@ class TrackSearch(TrackmanResource):
 
         # This means there was a bad search, stop searching
         if somesearch is False:
-            abort(400, success=False, message="No search entires")
+            return {
+                'success': False,
+                'message': "All provided fields to match against are empty",
+                'results': [],
+            }
 
         # Check if results
 
@@ -297,7 +301,11 @@ class TrackAutoComplete(TrackmanResource):
                 with_entities(models.Track.label).\
                 group_by(models.Track.label)
         else:
-            abort(400, success=False)
+            return {
+                'success': False,
+                'message': "Unknown field provided to use for autocomplete",
+                'results': [],
+            }
 
         # To verify some data was searched for
         somesearch = False
@@ -330,7 +338,11 @@ class TrackAutoComplete(TrackmanResource):
 
         # This means there was a bad search, stop searching
         if somesearch is False:
-            abort(400, success=False, message="No search entires")
+            return {
+                'success': False,
+                'message': "All provided fields to match against are empty",
+                'results': [],
+            }
 
         # Check if results
 


### PR DESCRIPTION
There are a few cases where Trackman clients may send searches that are
empty. Instead of returning a 400 error, just return a 200 error with no
results.

For autocomplete, we also do this if a field that we aren't able to
search on (e.g. vinyl) is provided. This is actually in line with the
existing search be behavior, which ignores fields it cannot search on.
In the future though, we may change this behavior.

This was caught by our Sentry error logging.