### PR TITLE
Only update extend autologout status when on air

### DIFF
--- a/trackman/static/js/trackman.js
+++ b/trackman/static/js/trackman.js
@@ -123,11 +123,14 @@ Trackman.prototype.validateTrack = function(track) {
 Trackman.prototype.initAutologout = function() {
     this.extendAutologout = false;
 
-    $.ajax({
-        url: this.baseUrl + "/api/autologout",
-        dataType: "json",
-        success: this.updateAutologout,
-    });
+    if(this.djsetId != null) {
+        $.ajax({
+            url: this.baseUrl + "/api/autologout",
+            dataType: "json",
+            success: this.updateAutologout,
+        });
+    }
+
     $('#id_extend_autologout').on('change', null, {'instance': this},
                                   this.toggleAutologout);
 };

--- a/trackman/templates/log.html
+++ b/trackman/templates/log.html
@@ -317,6 +317,6 @@
 {% endblock %}
 {% block js %}
 {{ super() }}
-<script src="{{ url_for('static', filename='js/trackman.js', v=19) }}"></script>
+<script src="{{ url_for('static', filename='js/trackman.js', v=20) }}"></script>
 <script src="{{ url_for('trackman_private.log_js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
The Trackman client makes an API call to get the current status of the
"extend autologout" checkbox during initialization. If a DJ is not
currently on air (and thus the djsetId is null), this would result in a
403. Instead, we should only make this API call if djsetId is not null
when initializing Trackman, meaning that the DJ is already on air and we
have a DJSet available to use.