### PR TITLE
no longer 'genres you can dj'

### DIFF
--- a/trackman/templates/reactivate.html
+++ b/trackman/templates/reactivate.html
@@ -54,7 +54,7 @@
     </div>
 
     <div class="form-group row">
-        <label class="col-sm-3 col-form-label control-label">Genres you can DJ</label>
+        <label class="col-sm-3 col-form-label control-label">Genres you DJ</label>
         <div class="col-sm-9">
             <span class="form-control-plaintext">{{ dj.genres }}</span>
         </div>

--- a/trackman/templates/register.html
+++ b/trackman/templates/register.html
@@ -60,7 +60,7 @@
     </div>
 
     <div class="form-group row{% if form.genres.errors|length > 0 %} has-error{% endif %}">
-        <label for="id_genres" class="col-sm-3 col-form-label control-label">Genres you can DJ</label>
+        <label for="id_genres" class="col-sm-3 col-form-label control-label">Genres you DJ</label>
         <div class="col-sm-9">
             <input type="text" name="genres" id="id_genres"
                  value="{{ form.genres.data or "" }}" required="required"


### PR DESCRIPTION
it was dumb to say "genres you can dj", as no-one ever filled it out sanely ("All of them :P" being a fairly common style of response). making it "genres you DJ" will make it more informative (although we should probably trash the field altogether, since it's not structured and we don't use it for anything).