### PR TITLE
Clamp down cross-origin access using Flask-CORS

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@ apscheduler
 click
 Flask
 Flask-Caching
+flask-cors
 Flask-Migrate
 flask-oidc
 Flask-RESTful

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ certifi==2019.6.16        # via requests, sentry-sdk
 chardet==3.0.4            # via requests
 click==7.0
 flask-caching==1.7.2
+flask-cors==3.0.8
 flask-migrate==2.5.2
 flask-oidc==1.4.0
 flask-restful==0.3.7
@@ -40,7 +41,7 @@ redis==3.2.1
 requests==2.22.0
 rsa==4.0                  # via oauth2client
 sentry-sdk[flask]==0.9.1
-six==1.12.0               # via apscheduler, flask-oidc, flask-restful, oauth2client, python-dateutil, sqlalchemy-utils
+six==1.12.0               # via apscheduler, flask-cors, flask-oidc, flask-restful, oauth2client, python-dateutil, sqlalchemy-utils
 sqlalchemy-utils==0.34.0
 sqlalchemy==1.3.5
 tzlocal==1.5.1            # via apscheduler

--- a/trackman/__init__.py
+++ b/trackman/__init__.py
@@ -144,7 +144,7 @@ def init_app():
 
     from .blueprints import private_bp
     app.register_blueprint(private_bp)
-    app.register_blueprint(api_bp, url_prefix='/api')
+    app.register_blueprint(api_bp)
     app.register_blueprint(library_bp, url_prefix='/library')
     playlists_cache.init_app(app, config={
         'CACHE_TYPE': "redis",

--- a/trackman/api/__init__.py
+++ b/trackman/api/__init__.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, json, make_response
+from flask_cors import CORS
 from flask_restful import Api
 
 from .v1.airlog import AirLog, AirLogList
@@ -16,63 +17,67 @@ from .v1.playlists import NowPlaying, Last15Tracks, LatestTrack, \
     PlaylistsByDay, PlaylistsByDateRange, PlaylistsTrackLogsByDateRange, \
     PlaylistDJs, PlaylistAllDJs, PlaylistsByDJ, Playlist, PlaylistTrack
 from .v1.internal import InternalPing
-from flask_restful.utils import cors
 
 
 api_bp = Blueprint('trackman_api', __name__)
+CORS(api_bp, resources={
+    r"/api/now_playing": {"origins": "*"},
+    r"/api/playlists/*": {"origins": "*"},
+    r"/api/charts/*": {"origins": "*"},
+})
+
 api = Api(api_bp)
-api.decorators = [cors.crossdomain(origin='*')]
-api.add_resource(AutomationLog, '/automation/log')
-api.add_resource(DJ, '/dj/<int:dj_id>')
-api.add_resource(DJSet, '/djset/<int:djset_id>')
-api.add_resource(DJSetEnd, '/djset/<int:djset_id>/end')
-api.add_resource(DJSetList, '/djset')
-api.add_resource(Track, '/track/<int:track_id>')
-api.add_resource(TrackReport, '/track/<int:track_id>/report')
-api.add_resource(TrackSearch, '/search')
-api.add_resource(TrackAutoComplete, '/autocomplete')
-api.add_resource(TrackList, '/track')
-api.add_resource(TrackLog, '/tracklog/edit/<int:tracklog_id>')
-api.add_resource(TrackLogList, '/tracklog')
-api.add_resource(AutologoutControl, '/autologout')
-api.add_resource(AirLog, '/airlog/edit/<int:airlog_id>')
-api.add_resource(AirLogList, '/airlog')
-api.add_resource(RotationList, '/rotations')
-api.add_resource(Charts, '/charts')
+api.add_resource(AutomationLog, '/api/automation/log')
+api.add_resource(DJ, '/api/dj/<int:dj_id>')
+api.add_resource(DJSet, '/api/djset/<int:djset_id>')
+api.add_resource(DJSetEnd, '/api/djset/<int:djset_id>/end')
+api.add_resource(DJSetList, '/api/djset')
+api.add_resource(Track, '/api/track/<int:track_id>')
+api.add_resource(TrackReport, '/api/track/<int:track_id>/report')
+api.add_resource(TrackSearch, '/api/search')
+api.add_resource(TrackAutoComplete, '/api/autocomplete')
+api.add_resource(TrackList, '/api/track')
+api.add_resource(TrackLog, '/api/tracklog/edit/<int:tracklog_id>')
+api.add_resource(TrackLogList, '/api/tracklog')
+api.add_resource(AutologoutControl, '/api/autologout')
+api.add_resource(AirLog, '/api/airlog/edit/<int:airlog_id>')
+api.add_resource(AirLogList, '/api/airlog')
+api.add_resource(RotationList, '/api/rotations')
+api.add_resource(Charts, '/api/charts')
 api.add_resource(AlbumCharts,
-                 '/charts/albums',
-                 '/charts/albums/<string:period>',
-                 '/charts/albums/<string:period>/<int:year>',
-                 '/charts/albums/<string:period>/<int:year>/<int:month>')
-api.add_resource(DJAlbumCharts, '/charts/dj/<int:dj_id>/albums')
+                 '/api/charts/albums',
+                 '/api/charts/albums/<string:period>',
+                 '/api/charts/albums/<string:period>/<int:year>',
+                 '/api/charts/albums/<string:period>/<int:year>/<int:month>')
+api.add_resource(DJAlbumCharts, '/api/charts/dj/<int:dj_id>/albums')
 api.add_resource(ArtistCharts,
-                 '/charts/artists',
-                 '/charts/artists/<string:period>',
-                 '/charts/artists/<string:period>/<int:year>',
-                 '/charts/artists/<string:period>/<int:year>/<int:month>')
-api.add_resource(DJArtistCharts, '/charts/dj/<int:dj_id>/artists')
+                 '/api/charts/artists',
+                 '/api/charts/artists/<string:period>',
+                 '/api/charts/artists/<string:period>/<int:year>',
+                 '/api/charts/artists/<string:period>/<int:year>/<int:month>')
+api.add_resource(DJArtistCharts, '/api/charts/dj/<int:dj_id>/artists')
 api.add_resource(TrackCharts,
-                 '/charts/tracks',
-                 '/charts/tracks/<string:period>',
-                 '/charts/tracks/<string:period>/<int:year>',
-                 '/charts/tracks/<string:period>/<int:year>/<int:month>')
-api.add_resource(DJTrackCharts, '/charts/dj/<int:dj_id>/tracks')
-api.add_resource(DJSpinCharts, '/charts/dj/spins')
-api.add_resource(DJVinylSpinCharts, '/charts/dj/vinyl_spins')
-api.add_resource(NowPlaying, '/now_playing')
-api.add_resource(Last15Tracks, '/playlists/last15')
-api.add_resource(LatestTrack, '/playlists/latest_track')
+                 '/api/charts/tracks',
+                 '/api/charts/tracks/<string:period>',
+                 '/api/charts/tracks/<string:period>/<int:year>',
+                 '/api/charts/tracks/<string:period>/<int:year>/<int:month>')
+api.add_resource(DJTrackCharts, '/api/charts/dj/<int:dj_id>/tracks')
+api.add_resource(DJSpinCharts, '/api/charts/dj/spins')
+api.add_resource(DJVinylSpinCharts, '/api/charts/dj/vinyl_spins')
+api.add_resource(NowPlaying, '/api/now_playing')
+api.add_resource(Last15Tracks, '/api/playlists/last15')
+api.add_resource(LatestTrack, '/api/playlists/latest_track')
 api.add_resource(PlaylistsTrackLogsByDateRange,
-                 '/playlists/tracklogs/date/range')
+                 '/api/playlists/tracklogs/date/range')
 api.add_resource(PlaylistsByDay,
-                 '/playlists/date/<int:year>/<int:month>/<int:day>')
-api.add_resource(PlaylistsByDateRange, '/playlists/date/range')
-api.add_resource(PlaylistDJs, '/playlists/dj')
-api.add_resource(PlaylistAllDJs, '/playlists/dj/all')
-api.add_resource(PlaylistsByDJ, '/playlists/dj/<int:dj_id>')
-api.add_resource(Playlist, '/playlists/set/<int:set_id>')
-api.add_resource(PlaylistTrack, '/playlists/track/<int:track_id>')
-api.add_resource(InternalPing, '/internal/ping')
+                 '/api/playlists/date/<int:year>/<int:month>/<int:day>')
+api.add_resource(PlaylistsByDateRange, '/api/playlists/date/range')
+api.add_resource(PlaylistDJs, '/api/playlists/dj')
+api.add_resource(PlaylistAllDJs, '/api/playlists/dj/all')
+api.add_resource(PlaylistsByDJ, '/api/playlists/dj/<int:dj_id>')
+api.add_resource(Playlist, '/api/playlists/set/<int:set_id>')
+api.add_resource(PlaylistTrack, '/api/playlists/track/<int:track_id>')
+api.add_resource(InternalPing, '/api/internal/ping')
 
 
 @api.representation('application/json')


### PR DESCRIPTION
Previously, we allowed cross-origin access for all Trackman API endpoints. This made us vulnerable to CSRF. Instead, let's now clamp down access to only allow the playlist and chart resources which are safe for cross-origin usage.