### PR TITLE
Remove (unused) Werkzeug cache initialization

### DIFF
--- a/trackman/__init__.py
+++ b/trackman/__init__.py
@@ -3,7 +3,6 @@ from flask import Flask, Request
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
-from werkzeug.contrib.cache import RedisCache
 import humanize
 import os
 import redis
@@ -91,7 +90,6 @@ if app.config['PROXY_FIX']:
 
 redis_conn = redis.from_url(app.config['REDIS_URL'])
 
-cache = RedisCache(host=redis_conn)
 csrf = CSRFProtect(app)
 db = SQLAlchemy(app)
 migrate = Migrate(app, db)


### PR DESCRIPTION
This has not been used in a while and needs to be removed to avoid weird
behavior when configuring a custom Redis URL for the cache.