### PR TITLE
Add support for automation using a different DJ

### DIFF
--- a/trackman/api/v1/djset.py
+++ b/trackman/api/v1/djset.py
@@ -98,6 +98,7 @@ class DJSetEnd(TrackmanResource):
             })
 
         if check_onair(djset_id):
+            redis_conn.delete('onair_dj_id')
             redis_conn.delete('onair_djset_id')
 
         # Reset the dj activity timeout period
@@ -172,6 +173,7 @@ class DJSetList(TrackmanResource):
             raise
         playlists_cache.clear()
 
+        redis_conn.set('onair_dj_id', dj_id)
         redis_conn.set('onair_djset_id', djset.id)
         session['djset_id'] = djset.id
 

--- a/trackman/forms.py
+++ b/trackman/forms.py
@@ -146,6 +146,7 @@ class AutomationTrackLogForm(FlaskForm):
     artist = StringField('Artist', filters=[strip_field])
     album = StringField('Album', filters=[strip_field])
     label = StringField('Label', filters=[strip_field])
+    dj_id = StringField('DJ ID')
 
 
 class TrackLogEditForm(FlaskForm):

--- a/trackman/lib.py
+++ b/trackman/lib.py
@@ -36,6 +36,7 @@ def renew_dj_lease(expire=None):
 
 
 def logout_all(send_email=False):
+    redis_conn.delete('onair_dj_id')
     redis_conn.delete('onair_djset_id')
 
     open_djsets = DJSet.query.\
@@ -96,6 +97,7 @@ def disable_automation():
         automation_set_id = redis_conn.get("onair_djset_id")
 
         redis_conn.set("automation_enabled", b"false")
+        redis_conn.delete('onair_dj_id')
         redis_conn.delete('onair_djset_id')
         current_app.logger.info("Trackman: Automation disabled")
 


### PR DESCRIPTION
With this change, the automation API now supports an optional dj_id
field which can be used to change the DJ used for the DJSet. This will
be used for prerecorded shows to log under the correct DJ.