### PR TITLE
Add bulk edit functionality to library

### DIFF
--- a/trackman/forms.py
+++ b/trackman/forms.py
@@ -1,9 +1,29 @@
 from flask import current_app
 from flask_wtf import FlaskForm
-from wtforms import BooleanField, IntegerField, StringField, \
-    ValidationError, validators
+from wtforms import validators, ValidationError
+from wtforms.fields import BooleanField, IntegerField, StringField
+from wtforms.widgets import Select, TextInput
 from .models import DJ
 from .view_utils import slugify
+
+
+class BootstrapWidgetMixin(object):
+    def __call__(self, field, **kwargs):
+        existing_class = kwargs.pop("class", "") or kwargs.pop("class_", "")
+        classes = set(existing_class.split())
+        classes.add("form-control")
+        if field.errors:
+            classes.add("is-invalid")
+        kwargs["class"] = " ".join(classes)
+        return super().__call__(field, **kwargs)
+
+
+class BootstrapSelect(BootstrapWidgetMixin, Select):
+    pass
+
+
+class BootstrapTextInput(BootstrapWidgetMixin, TextInput):
+    pass
 
 
 def strip_field(val):

--- a/trackman/library/forms.py
+++ b/trackman/library/forms.py
@@ -1,0 +1,54 @@
+from flask_wtf import FlaskForm
+from wtforms import validators
+from wtforms.fields import BooleanField, HiddenField, StringField
+from wtforms.widgets import HiddenInput
+from trackman.forms import BootstrapTextInput
+
+
+class BulkEditForm(FlaskForm):
+    edit_from = HiddenField("Edit From")
+    submit = BooleanField(
+        "Form Submitted",
+        validators=[validators.DataRequired()],
+        widget=HiddenInput(),
+    )
+    artist = StringField(
+        "Artist",
+        validators=[validators.Optional()],
+        widget=BootstrapTextInput(),
+    )
+    title = StringField(
+        "Title",
+        validators=[validators.Optional()],
+        widget=BootstrapTextInput(),
+    )
+    album = StringField(
+        "Album",
+        validators=[validators.Optional()],
+        widget=BootstrapTextInput(),
+    )
+    label = StringField(
+        "Label",
+        validators=[validators.Optional()],
+        widget=BootstrapTextInput(),
+    )
+    artist_mbid = StringField(
+        "Artist MBID",
+        validators=[validators.Optional(), validators.UUID()],
+        widget=BootstrapTextInput(),
+    )
+    recording_mbid = StringField(
+        "Recording MBID",
+        validators=[validators.Optional(), validators.UUID()],
+        widget=BootstrapTextInput(),
+    )
+    release_mbid = StringField(
+        "Release MBID",
+        validators=[validators.Optional(), validators.UUID()],
+        widget=BootstrapTextInput(),
+    )
+    releasegroup_mbid = StringField(
+        "Release Group MBID",
+        validators=[validators.Optional(), validators.UUID()],
+        widget=BootstrapTextInput(),
+    )

--- a/trackman/library/views.py
+++ b/trackman/library/views.py
@@ -3,11 +3,12 @@ from flask import abort, current_app, flash, render_template, redirect, \
 import string
 import uuid
 
-from trackman import auth_manager, db, format_datetime
+from trackman import auth_manager, db
 from trackman.models import DJ, Track, TrackLog, TrackReport
 from trackman.lib import deduplicate_track_by_id
 from trackman.musicbrainz import musicbrainzngs
 from . import library_bp
+from .forms import BulkEditForm
 
 
 def validate_uuid(uuid_str):
@@ -422,3 +423,49 @@ def track_spins(id):
 
     return render_template('library/track_spins.html', track=track,
                            edit_from=edit_from, tracklogs=tracklogs)
+
+
+@library_bp.route('/bulk-edit', methods=['POST'])
+@auth_manager.check_access('library')
+def bulk_edit():
+    fields_to_set = ('artist', 'title', 'album', 'label', 'artist_mbid',
+                     'recording_mbid', 'release_mbid', 'releasegroup_mbid')
+    track_ids = [int(x) for x in request.form.getlist('track_ids[]')]
+
+    form_defaults = {}
+    for track_id in track_ids:
+        track = Track.query.get(track_id)
+        for field in fields_to_set:
+            value = getattr(track, field)
+            if form_defaults.get(field) is None:
+                form_defaults[field] = value
+            elif form_defaults.get(field) != value:
+                form_defaults[field] = None
+
+    form = BulkEditForm(submit=True, **form_defaults)
+
+    if form.validate_on_submit():
+        for track_id in track_ids:
+            track = Track.query.get(track_id)
+
+            for field in fields_to_set:
+                if len(form[field].data) > 0:
+                    setattr(track, field, form[field].data)
+
+        db.session.commit()
+
+        if form.edit_from.data == "artist":
+            return redirect(url_for('trackman_library.artist',
+                                    artist=track.artist))
+        elif form.edit_from.data == "album":
+            return redirect(url_for('trackman_library.album',
+                                    album=track.album))
+        elif form.edit_from.data == 'label':
+            return redirect(url_for('trackman_library.label',
+                                    label=track.label))
+        else:
+            return redirect(url_for('trackman_library.index'))
+
+    return render_template('library/bulk_edit.html',
+                           track_ids=track_ids,
+                           form=form)

--- a/trackman/library/views.py
+++ b/trackman/library/views.py
@@ -435,11 +435,18 @@ def bulk_edit():
     form_defaults = {}
     for track_id in track_ids:
         track = Track.query.get(track_id)
+
+        # Iterate through the list of fields above
         for field in fields_to_set:
             value = getattr(track, field)
-            if form_defaults.get(field) is None:
+
+            # For each field, check if we already have a default value set.
+            if field not in form_defaults:
+                # No default set, use the first one
                 form_defaults[field] = value
             elif form_defaults.get(field) != value:
+                # Our value is different, reset value to None
+                # We won't be able to display anything here
                 form_defaults[field] = None
 
     form = BulkEditForm(submit=True, **form_defaults)

--- a/trackman/static/js/library.js
+++ b/trackman/static/js/library.js
@@ -1,0 +1,4 @@
+$('.bulk-edit-select-all').change(function() {
+    var checkboxes = $(this).closest('form').find(':checkbox');
+    checkboxes.prop('checked', $(this).is(':checked'));
+});

--- a/trackman/templates/library/artist.html
+++ b/trackman/templates/library/artist.html
@@ -13,5 +13,10 @@
 
 <h1>Artist: {{ artist }}</h1>
 
-{{ macros.library_tracklist(tracks) }}
+{{ macros.library_tracklist(tracks, edit_from='artist') }}
+{% endblock %}
+
+{% block js %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/library.js') }}"></script>
 {% endblock %}

--- a/trackman/templates/library/bulk_edit.html
+++ b/trackman/templates/library/bulk_edit.html
@@ -1,0 +1,112 @@
+{% extends "admin/base.html" %}
+{% set page_title="Bulk Edit" %}
+{% block nav_admin_library %}<li class="nav-item "><a class="nav-link active" href="{{ url_for('trackman_library.index') }}">Library</a></li>{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('trackman_library.index') }}">Library</a></li>
+        <li class="breadcrumb-item active">Bulk Edit</li>
+    </ol>
+</nav>
+
+<h1>Bulk Edit</h1>
+
+<div class="card-body">
+    <form method="post" class="form-horizontal" role="form">
+        {{ form.hidden_tag() }}
+
+{% for track_id in track_ids %}
+        <input type="hidden" name="track_ids[]" value="{{ track_id }}"/>
+{% endfor %}
+
+        <div class="form-group row{% if form.artist.errors|length > 0 %} has-error{% endif %}">
+            {{ form.artist.label(class_="col-sm-3 col-form-label control-label") }}
+            <div class="col-sm-9">
+                {{ form.artist }}
+{% for error in form.artist.errors %}
+                <div class="help-block">{{ error }}</div>
+{% endfor %}
+            </div>
+        </div>
+        
+        <div class="form-group row{% if form.title.errors|length > 0 %} has-error{% endif %}">
+            {{ form.title.label(class_="col-sm-3 col-form-label control-label") }}
+            <div class="col-sm-9">
+                {{ form.title }}
+{% for error in form.title.errors %}
+                <div class="help-block">{{ error }}</div>
+{% endfor %}
+            </div>
+        </div>
+
+        <div class="form-group row{% if form.album.errors|length > 0 %} has-error{% endif %}">
+            {{ form.album.label(class_="col-sm-3 col-form-label control-label") }}
+            <div class="col-sm-9">
+                {{ form.album }}
+{% for error in form.album.errors %}
+                <div class="help-block">{{ error }}</div>
+{% endfor %}
+            </div>
+        </div>
+        
+        <div class="form-group row{% if form.label.errors|length > 0 %} has-error{% endif %}">
+            {{ form.label.label(class_="col-sm-3 col-form-label control-label") }}
+            <div class="col-sm-9">
+                {{ form.label }}
+{% for error in form.label.errors %}
+                <div class="help-block">{{ error }}</div>
+{% endfor %}
+            </div>
+        </div>
+
+        <div class="form-group row{% if form.artist_mbid.errors|length > 0 %} has-error{% endif %}">
+            {{ form.artist_mbid.label(class_="col-sm-3 col-form-label control-label") }}
+            <div class="col-sm-9">
+                {{ form.artist_mbid }}
+{% for error in form.artist_mbid.errors %}
+                <div class="help-block">{{ error }}</div>
+{% endfor %}
+            </div>
+        </div>
+
+        <div class="form-group row{% if form.recording_mbid.errors|length > 0 %} has-error{% endif %}">
+            {{ form.recording_mbid.label(class_="col-sm-3 col-form-label control-label") }}
+            <div class="col-sm-9">
+                {{ form.recording_mbid }}
+{% for error in form.recording_mbid.errors %}
+                <div class="help-block">{{ error }}</div>
+{% endfor %}
+            </div>
+        </div>
+
+        <div class="form-group row{% if form.release_mbid.errors|length > 0 %} has-error{% endif %}">
+            {{ form.release_mbid.label(class_="col-sm-3 col-form-label control-label") }}
+            <div class="col-sm-9">
+                {{ form.release_mbid }}
+{% for error in form.release_mbid.errors %}
+                <div class="help-block">{{ error }}</div>
+{% endfor %}
+            </div>
+        </div>
+
+        <div class="form-group row{% if form.releasegroup_mbid.errors|length > 0 %} has-error{% endif %}">
+            {{ form.releasegroup_mbid.label(class_="col-sm-3 col-form-label control-label") }}
+            <div class="col-sm-9">
+                {{ form.releasegroup_mbid }}
+{% for error in form.releasegroup_mbid.errors %}
+                <div class="help-block">{{ error }}</div>
+{% endfor %}
+            </div>
+        </div>
+
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary">
+                <span class="oi oi-check"></span>
+                Save Changes
+            </button>
+        </div>
+    </form>
+</div>
+
+{% endblock %}

--- a/trackman/templates/library/dj.html
+++ b/trackman/templates/library/dj.html
@@ -34,6 +34,11 @@
 </dl>
 
 {{ macros.render_pagination(tracks, 'trackman_library.dj', id=dj.id) }}
-{{ macros.library_tracklist(tracks.items) }}
+{{ macros.library_tracklist(tracks.items, edit_from='dj') }}
 {{ macros.render_pagination(tracks, 'trackman_library.dj', id=dj.id) }}
+{% endblock %}
+
+{% block js %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/library.js') }}"></script>
 {% endblock %}

--- a/trackman/templates/library/fixup_tracks.html
+++ b/trackman/templates/library/fixup_tracks.html
@@ -14,6 +14,11 @@
 <h1>Fixup: {{ title }}</h1>
 
 {{ macros.render_pagination(tracks, 'trackman_library.fixup_tracks', key=key) }}
-{{ macros.library_tracklist(tracks.items) }}
+{{ macros.library_tracklist(tracks.items, edit_from='fixup_tracks') }}
 {{ macros.render_pagination(tracks, 'trackman_library.fixup_tracks', key=key) }}
+{% endblock %}
+
+{% block js %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/library.js') }}"></script>
 {% endblock %}

--- a/trackman/templates/library/index.html
+++ b/trackman/templates/library/index.html
@@ -26,7 +26,9 @@
         <label for="artist" class="col-sm-1 control-label col-form-label">Artist</label>
         <div class="col-sm input-group">
             <input class="form-control" type="text" id="artist" name="artist"/>
-            <button type="submit" class="btn btn-primary">Search</button>
+            <div class="input-group-append">
+                <button type="submit" class="btn btn-primary">Search</button>
+            </div>
         </div>
     </div>
     </form>

--- a/trackman/templates/library/label.html
+++ b/trackman/templates/library/label.html
@@ -14,6 +14,11 @@
 <h1>Label: {{ label }}</h1>
 
 {{ macros.render_pagination(tracks, 'trackman_library.label', label=label) }}
-{{ macros.library_tracklist(tracks.items, track_from='label') }}
+{{ macros.library_tracklist(tracks.items, track_from='label', edit_from='label') }}
 {{ macros.render_pagination(tracks, 'trackman_library.label', label=label) }}
+{% endblock %}
+
+{% block js %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/library.js') }}"></script>
 {% endblock %}

--- a/trackman/templates/library/labels.html
+++ b/trackman/templates/library/labels.html
@@ -27,7 +27,9 @@
         <label for="label" class="col-sm-1 control-label col-form-label">Label</label>
         <div class="col-sm input-group">
             <input class="form-control" type="text" id="label" name="label"/>
-            <button type="submit" class="btn btn-primary">Search</button>
+            <div class="input-group-append">
+                <button type="submit" class="btn btn-primary">Search</button>
+            </div>
         </div>
     </div>
     </form>

--- a/trackman/templates/library/macros.html
+++ b/trackman/templates/library/macros.html
@@ -28,9 +28,16 @@
 {% endif %}
 {% endmacro %}
 
-{% macro library_tracklist(tracks, track_from=None) %}
+{% macro library_tracklist(tracks, track_from=None, edit_from=None) %}
+<form action="{{ url_for('trackman_library.bulk_edit') }}" method="post">
+<input type="hidden" name="_csrf_token" value="{{ csrf_token() }}"/>
+{% if edit_from is not none %}
+<input type="hidden" name="edit_from" value="{{ edit_from }}"/>
+{% endif %}
+
 <table class="table table-striped table-hover">
     <tr>
+        <th><input type="checkbox" class="bulk-edit-select-all" value="" title="Select all tracks in this table"/></th>
         <th>Artist</th>
         <th>Title</th>
         <th>Album</th>
@@ -39,11 +46,23 @@
 
     {% for track in tracks -%}
     <tr>
+        <td><input type="checkbox" name="track_ids[]" id="track_ids-{{ track.id }}-checkbox" value="{{ track.id }}"/></td>
         <td><a href="{{ url_for('trackman_library.artist', artist=track.artist) }}">{{ track.artist }}</a></td>
         <td><a href="{{ url_for('trackman_library.track', id=track.id, from=track_from) }}">{{ track.title }}</a></td>
         <td>{{ track.album }}</td>
         <td><a href="{{ url_for('trackman_library.label', label=track.label) }}">{{ track.label }}</a></td>
     </tr>
     {% endfor -%}
+
+    <tr>
+        <td colspan="5">
+            <button type="submit" class="btn btn-primary">
+                <span class="oi oi-wrench"></span>
+                Edit Selected Tracks
+            </button>
+        </td>
+    </tr>
 </table>
+
+</form>
 {% endmacro %}

--- a/trackman/templates/library/track.html
+++ b/trackman/templates/library/track.html
@@ -72,7 +72,7 @@
                     <input type="text" name="artist_mbid" id="id_artist_mbid"
                         value="{{ data.artist_mbid or "" }}"
                         class="form-control"/>
-                    <span class="input-group-btn">
+                    <span class="input-group-append">
                         {% if track.artist_mbid %}
                         <a href="https://musicbrainz.org/artist/{{ track.artist_mbid }}"
                                 rel="external noreferrer"
@@ -96,7 +96,7 @@
                         id="id_recording_mbid"
                         value="{{ data.recording_mbid or "" }}"
                         class="form-control"/>
-                    <span class="input-group-btn">
+                    <span class="input-group-append">
                         {% if track.recording_mbid %}
                         <a href="https://musicbrainz.org/recording/{{ track.recording_mbid }}"
                                 rel="external noreferrer"
@@ -118,7 +118,7 @@
                     <input type="text" name="release_mbid" id="id_release_mbid"
                         value="{{ data.release_mbid or "" }}"
                         class="form-control"/>
-                    <span class="input-group-btn">
+                    <span class="input-group-append">
                         {% if track.release_mbid %}
                         <a href="https://musicbrainz.org/release/{{ track.release_mbid }}"
                                 rel="external noreferrer"
@@ -141,7 +141,7 @@
                         id="id_releasegroup_mbid"
                         value="{{ data.releasegroup_mbid or "" }}"
                         class="form-control"/>
-                    <span class="input-group-btn">
+                    <span class="input-group-append">
                         {% if track.releasegroup_mbid %}
                         <a href="https://musicbrainz.org/release-group/{{ track.releasegroup_mbid }}"
                                 rel="external noreferrer"


### PR DESCRIPTION
Add the ability to select multiple tracks and make the same changes to all of them at once.

Closes #45.
Makes the task described in #43 easier.

I also rolled in two tiny UI fixes to use the `input-group-append` Bootstrap class where appropriate.

![Selecting tracks](https://user-images.githubusercontent.com/67266/88873458-86504900-d1d1-11ea-88b9-68ebcdc2ea46.png)
![Editing selected tracks](https://user-images.githubusercontent.com/67266/88873454-851f1c00-d1d1-11ea-98af-db30ff7f9395.png)