### PR TITLE
Add "MusicBrainz Release Groups" tool

### DIFF
--- a/trackman/library/forms.py
+++ b/trackman/library/forms.py
@@ -65,6 +65,8 @@ class BulkEditForm(FlaskForm):
 
 
 class ArtistMusicbrainzAlbumForm(FlaskForm):
+    """Subform used in ArtistMusicbrainzForm to match albums and release group
+    MBIDs."""
     album = HiddenField(
         "Album",
         validators=[validators.InputRequired()],
@@ -77,6 +79,9 @@ class ArtistMusicbrainzAlbumForm(FlaskForm):
 
 
 class ArtistMusicbrainzForm(FlaskForm):
+    """Form used on the artist "MusicBrainz Release Groups" page to associate
+    release groups with albums. We use a list of ArtistMusicbrainzAlbumForm
+    instances in combination with the artist to do this matching."""
     artist = HiddenField(
         "Artist",
         validators=[validators.InputRequired()],

--- a/trackman/library/forms.py
+++ b/trackman/library/forms.py
@@ -1,6 +1,8 @@
 from flask_wtf import FlaskForm
 from wtforms import validators
-from wtforms.fields import BooleanField, HiddenField, StringField
+from wtforms.fields import (
+    BooleanField, FieldList, FormField, HiddenField, StringField
+)
 from wtforms.widgets import HiddenInput
 from trackman.forms import BootstrapTextInput, strip_field
 
@@ -60,3 +62,27 @@ class BulkEditForm(FlaskForm):
         validators=[validators.Optional(), validators.UUID()],
         widget=BootstrapTextInput(),
     )
+
+
+class ArtistMusicbrainzAlbumForm(FlaskForm):
+    album = HiddenField(
+        "Album",
+        validators=[validators.InputRequired()],
+    )
+    releasegroup_mbid = HiddenField(
+        "Release Group MBID",
+        filters=[strip_field],
+        validators=[validators.Optional(), validators.UUID()],
+    )
+
+
+class ArtistMusicbrainzForm(FlaskForm):
+    artist = HiddenField(
+        "Artist",
+        validators=[validators.InputRequired()],
+    )
+    artist_mbid = HiddenField(
+        "Artist MBID",
+        validators=[validators.InputRequired(), validators.UUID()],
+    )
+    albums = FieldList(FormField(ArtistMusicbrainzAlbumForm))

--- a/trackman/library/views.py
+++ b/trackman/library/views.py
@@ -98,6 +98,9 @@ def artist():
 @library_bp.route('/artist-musicbrainz', methods=['GET', 'POST'])
 @auth_manager.check_access('library')
 def artist_musicbrainz():
+    """This view that displays/handles the "MusicBrainz Release Groups"
+    functionality on the artist page."""
+
     if request.method == "GET":
         artist = request.args['artist']
         artist_mbid = request.args['artist_mbid']

--- a/trackman/library/views.py
+++ b/trackman/library/views.py
@@ -8,7 +8,7 @@ from trackman.models import DJ, Track, TrackLog, TrackReport
 from trackman.lib import deduplicate_track_by_id
 from trackman.musicbrainz import musicbrainzngs
 from . import library_bp
-from .forms import BulkEditForm
+from .forms import BulkEditForm, ArtistMusicbrainzForm
 
 
 def validate_uuid(uuid_str):
@@ -78,8 +78,85 @@ def artist():
     tracks = Track.query.filter(Track.artist == artist).\
         order_by(Track.album, Track.title).all()
 
-    return render_template('library/artist.html', artist=artist,
-                           tracks=tracks)
+    artist_mbids = Track.query.with_entities(
+        Track.artist_mbid,
+    ).group_by(
+        Track.artist_mbid,
+    ).filter(
+        Track.artist == artist,
+        Track.artist_mbid != None,
+    ).all()
+
+    return render_template(
+        'library/artist.html',
+        artist=artist,
+        tracks=tracks,
+        artist_mbids=[x.artist_mbid for x in artist_mbids],
+    )
+
+
+@library_bp.route('/artist-musicbrainz', methods=['GET', 'POST'])
+@auth_manager.check_access('library')
+def artist_musicbrainz():
+    if request.method == "GET":
+        artist = request.args['artist']
+        artist_mbid = request.args['artist_mbid']
+        form = ArtistMusicbrainzForm(artist=artist, artist_mbid=artist_mbid)
+    else:
+        form = ArtistMusicbrainzForm()
+        artist = form.artist.data
+        artist_mbid = form.artist_mbid.data
+
+    musicbrainzngs.set_hostname(current_app.config['MUSICBRAINZ_HOSTNAME'])
+    musicbrainzngs.set_rate_limit(current_app.config['MUSICBRAINZ_RATE_LIMIT'])
+
+    # This will only return at most 25 release groups
+    result = musicbrainzngs.get_artist_by_id(
+        artist_mbid,
+        includes=["release-groups"],
+    )
+
+    if form.validate_on_submit():
+        releasegroup_to_album_name = {}
+        for r in result["artist"]["release-group-list"]:
+            releasegroup_to_album_name[r["id"]] = r["title"]
+
+        for entry in form.albums.entries:
+            tracks = Track.query.filter(
+                Track.artist == artist,
+                Track.album == entry.data['album'],
+            ).all()
+            for track in tracks:
+                releasegroup_mbid = entry.data['releasegroup_mbid']
+                if len(releasegroup_mbid) > 0:
+                    track.album = releasegroup_to_album_name[releasegroup_mbid]
+                    track.releasegroup_mbid = releasegroup_mbid
+
+            db.session.commit()
+
+        return redirect(url_for('trackman_library.artist', artist=artist))
+
+    # Get list of unique albums for this artist
+    albums = Track.query.with_entities(
+        Track.artist,
+        Track.album,
+    ).group_by(
+        Track.artist,
+        Track.album,
+    ).filter(
+        Track.artist == artist,
+    ).order_by(
+        Track.album,
+    ).all()
+
+    return render_template(
+        'library/artist_musicbrainz.html',
+        artist=artist,
+        artist_mbid=artist_mbid,
+        form=form,
+        albums=albums,
+        mb_releasegroups=result["artist"]["release-group-list"],
+    )
 
 
 @library_bp.route('/labels')

--- a/trackman/library/views.py
+++ b/trackman/library/views.py
@@ -431,6 +431,8 @@ def bulk_edit():
     form_defaults = {}
     for track_id in track_ids:
         track = Track.query.get(track_id)
+        if track is None:
+            abort(400)
 
         # Iterate through the list of fields above
         for field in fields_to_set:

--- a/trackman/musicbrainz.py
+++ b/trackman/musicbrainz.py
@@ -1,4 +1,4 @@
 import musicbrainzngs
 
-musicbrainzngs.set_useragent("Trackman", "20180411",
+musicbrainzngs.set_useragent("Trackman", "20200802",
                              "https://github.com/wuvt/trackman")

--- a/trackman/templates/library/artist.html
+++ b/trackman/templates/library/artist.html
@@ -17,7 +17,7 @@
 
 <div class="card">
     <div class="card-header">
-        MusicBrainz Helper
+        MusicBrainz Release Groups
     </div>
     <div class="card-body">
         <form action="{{ url_for('trackman_library.artist_musicbrainz') }}" method="get" class="form-horizontal" role="form">

--- a/trackman/templates/library/artist.html
+++ b/trackman/templates/library/artist.html
@@ -14,6 +14,35 @@
 <h1>Artist: {{ artist }}</h1>
 
 {{ macros.library_tracklist(tracks, edit_from='artist') }}
+
+<div class="card">
+    <div class="card-header">
+        MusicBrainz Helper
+    </div>
+    <div class="card-body">
+        <form action="{{ url_for('trackman_library.artist_musicbrainz') }}" method="get" class="form-horizontal" role="form">
+            <input type="hidden" name="artist" value="{{ artist }}"/>
+
+            <div class="form-group row">
+                <label for="artist_mbid" class="col-sm-2 control-label col-form-label">Artist MBID</label>
+                <div class="col-sm">
+                    <input class="form-control" type="text" name="artist_mbid" id="artist_mbid" list="artist_mbids" autocomplete="off"/>
+                    <datalist id="artist_mbids">
+{% for artist_mbid in artist_mbids %}
+                        <option value="{{ artist_mbid }}"/>
+{% endfor %}
+                    </datalist>
+                </div>
+            </div>
+            <div class="form-actions">
+                <button type="submit" class="btn btn-primary">
+                    <span class="oi oi-check"></span>
+                    Lookup
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
 {% endblock %}
 
 {% block js %}

--- a/trackman/templates/library/artist.html
+++ b/trackman/templates/library/artist.html
@@ -26,7 +26,7 @@
             <div class="form-group row">
                 <label for="artist_mbid" class="col-sm-2 control-label col-form-label">Artist MBID</label>
                 <div class="col-sm">
-                    <input class="form-control" type="text" name="artist_mbid" id="artist_mbid" list="artist_mbids" autocomplete="off"/>
+                    <input class="form-control" type="text" name="artist_mbid" id="artist_mbid" list="artist_mbids" autocomplete="off" required="required"/>
                     <datalist id="artist_mbids">
 {% for artist_mbid in artist_mbids %}
                         <option value="{{ artist_mbid }}"/>

--- a/trackman/templates/library/artist_musicbrainz.html
+++ b/trackman/templates/library/artist_musicbrainz.html
@@ -1,6 +1,6 @@
 {% import "library/macros.html" as macros %}
 {% extends "admin/base.html" %}
-{% set page_title="Artist: " + artist %}
+{% set page_title="MusicBrainz Release Groups for Artist: " + artist %}
 {% block nav_admin_library %}<li class="nav-item "><a class="nav-link active" href="{{ url_for('trackman_library.index') }}">Library</a></li>{% endblock %}
 
 {% block content %}
@@ -11,7 +11,7 @@
     </ol>
 </nav>
 
-<h1>Artist: {{ artist }}</h1>
+<h1>MusicBrainz Release Groups for Artist: {{ artist }}</h1>
 
 <form action="{{ url_for('trackman_library.artist_musicbrainz') }}" method="post" role="form">
 {{ form.hidden_tag() }}

--- a/trackman/templates/library/artist_musicbrainz.html
+++ b/trackman/templates/library/artist_musicbrainz.html
@@ -7,11 +7,12 @@
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{{ url_for('trackman_library.index') }}">Library</a></li>
-        <li class="breadcrumb-item active" aria-current="page">Artist: {{ artist }}</li>
+        <li class="breadcrumb-item"><a href="{{ url_for('trackman_library.artist', artist=artist) }}">Artist: {{ artist }}</a></li>
+        <li class="breadcrumb-item active" aria-current="page">MusicBrainz Release Groups</li>
     </ol>
 </nav>
 
-<h1>MusicBrainz Release Groups for Artist: {{ artist }}</h1>
+<h1>MusicBrainz Release Groups</h1>
 
 <form action="{{ url_for('trackman_library.artist_musicbrainz') }}" method="post" role="form">
 {{ form.hidden_tag() }}

--- a/trackman/templates/library/artist_musicbrainz.html
+++ b/trackman/templates/library/artist_musicbrainz.html
@@ -1,0 +1,61 @@
+{% import "library/macros.html" as macros %}
+{% extends "admin/base.html" %}
+{% set page_title="Artist: " + artist %}
+{% block nav_admin_library %}<li class="nav-item "><a class="nav-link active" href="{{ url_for('trackman_library.index') }}">Library</a></li>{% endblock %}
+
+{% block content %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ url_for('trackman_library.index') }}">Library</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Artist: {{ artist }}</li>
+    </ol>
+</nav>
+
+<h1>Artist: {{ artist }}</h1>
+
+<form action="{{ url_for('trackman_library.artist_musicbrainz') }}" method="post" role="form">
+{{ form.hidden_tag() }}
+
+<table class="table table-striped table-hover">
+    <tr>
+        <th>Artist</th>
+        <th>Album</th>
+        <th>MusicBrainz Release Group</th>
+    </tr>
+
+    {% for album in albums -%}
+    <tr>
+        <td>{{ album.artist }}</td>
+        <td>{{ album.album }}</td>
+        <td>
+            <input type="hidden" name="albums-{{ loop.index0 }}-album" value="{{ album.album }}"/>
+            <select name="albums-{{ loop.index0 }}-releasegroup_mbid" class="form-control">
+                <option value=""></option>
+{% for releasegroup in mb_releasegroups %}
+                <option value="{{ releasegroup.id }}">
+                    {{ releasegroup.title }}
+                    ({{ releasegroup.type }}{% if releasegroup['first-release-date']|length > 0 %} {{ releasegroup['first-release-date'] }}{% endif %})
+                </option>
+{% endfor %}
+            </select>
+        </td>
+    </tr>
+    {% endfor -%}
+
+    <tr>
+        <td colspan="3">
+            <button type="submit" class="btn btn-primary">
+                <span class="oi oi-check"></span>
+                Apply Release Groups
+            </button>
+        </td>
+    </tr>
+</table>
+
+</form>
+{% endblock %}
+
+{% block js %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/library.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
This feature allows for a MusicBrainz artist MBID to be entered (or
selected) on the artist page. From there, the user is presented with a
list of unique artist/album combinations and a dropdown to select a
corresponding release group.

If a release group is selected, the album and release group MBIDs are
updated for all tracks matching the search.

This functionality is not perfect as it does not handle cases where the
album names are identical across multiple albums, but it should improve
the workflow for doing this quite a bit.

Fixes #43.

![View on artist page](https://user-images.githubusercontent.com/67266/89255177-e847ee80-d5d5-11ea-9e80-33c03b65c637.png)
![View of tool with "Apply Release Groups" button](https://user-images.githubusercontent.com/67266/89256249-89d03f80-d5d8-11ea-889f-97fb085d5380.png)