### PR TITLE
Add authenticated user to uWSGI logs

### DIFF
--- a/trackman/auth/auth_manager.py
+++ b/trackman/auth/auth_manager.py
@@ -150,7 +150,7 @@ class AuthManager(object):
                     self.db.session.rollback()
                     raise
 
-        _request_ctx_stack.top.user = None
+        _request_ctx_stack.top.user = AnonymousUserMixin()
         _request_ctx_stack.top.user_roles = set([])
         return True
 

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -10,6 +10,8 @@ enable-threads = 1
 module = trackman
 callable = app
 
+log-format = [pid: %(pid)|app: -|req: -/-] %(addr) (%(app_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))
+
 [dev]
 procname-prefix-spaced = trackman
 uid = www-data
@@ -21,3 +23,5 @@ enable-threads = 1
 
 module = trackman
 callable = app
+
+log-format = [pid: %(pid)|app: -|req: -/-] %(addr) (%(app_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))


### PR DESCRIPTION
To make auditing and debugging easier, it is helpful to include the
current authenticated user in the request log. We do this by setting a
uWSGI log variable in the application and overriding the uWSGI log
format to use this variable instead of the REMOTE_USER of the request.

Unfortunately, uWSGI is weird and we lose some information when we
override the log format, like the app ID and whatever "req" specifies in
the logs. This shouldn't affect anything we're doing, but it's
unfortunate nonetheless.

Also, when there is no user logged in or the Python application is
bypassed, the user will be "-" instead of the empty string.

This is basically identical to https://github.com/wuvt/wuvt-site/pull/394 where it is now running in production and is working as expected.