### PR TITLE
Allow uwsgi import to fail gracefully

### DIFF
--- a/trackman/__init__.py
+++ b/trackman/__init__.py
@@ -8,12 +8,16 @@ import os
 import redis
 from . import defaults
 import uuid
-import uwsgi
 import datetime
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+
+try:
+    import uwsgi
+except ImportError:
+    pass
 
 json_mimetypes = ['application/json']
 
@@ -118,7 +122,7 @@ def inject_year():
 
 @app.after_request
 def add_app_user_logvar(response):
-    if current_user.is_authenticated:
+    if uwsgi is not None and current_user.is_authenticated:
         uwsgi.set_logvar('app_user', current_user.sub)
     return response
 


### PR DESCRIPTION
It seems that `import uwsgi` only works when the app is being run by
uWSGI and not via the `flask` command. To prevent breakage, we need to
ensure that a failed import of the uwsgi module fails gracefully.