### PR TITLE
Bump dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 apscheduler
-Authlib<13.0
+Authlib
 click
+email_validator
 Flask
 Flask-Caching
 flask-cors

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,164 +5,66 @@
 #    pip-compile
 #
 -e git+https://github.com/wuvt/python-musicbrainzngs#egg=musicbrainzngs  # via -r requirements.in
-    # via -r requirements.in
-alembic==1.3.1
-    # via flask-migrate
-aniso8601==8.0.0
-    # via flask-restful
-apscheduler==3.6.3
-    # via -r requirements.in
-authlib==0.12.1
-    # via
-    #   -r requirements.in
-    #   loginpass
-blinker==1.4
-    # via sentry-sdk
-cachetools==3.1.1
-    # via google-auth
-certifi==2019.11.28
-    # via
-    #   requests
-    #   sentry-sdk
-cffi==1.13.2
-    # via cryptography
-chardet==3.0.4
-    # via requests
-click==7.0
-    # via
-    #   -r requirements.in
-    #   flask
-cryptography==3.3.2
-    # via authlib
-flask-caching==1.7.2
-    # via -r requirements.in
-flask-cors==3.0.9
-    # via -r requirements.in
-flask-migrate==2.5.2
-    # via -r requirements.in
-flask-restful==0.3.7
-    # via -r requirements.in
-flask-sqlalchemy==2.4.1
-    # via
-    #   -r requirements.in
-    #   flask-migrate
-flask-wtf==0.14.2
-    # via -r requirements.in
-flask==1.1.1
-    # via
-    #   -r requirements.in
-    #   flask-caching
-    #   flask-cors
-    #   flask-migrate
-    #   flask-restful
-    #   flask-sqlalchemy
-    #   flask-wtf
-    #   sentry-sdk
-google-api-python-client==1.7.11
-    # via -r requirements.in
-google-auth-httplib2==0.0.3
-    # via google-api-python-client
-google-auth==1.7.2
-    # via
-    #   google-api-python-client
-    #   google-auth-httplib2
-httplib2==0.19.0
-    # via
-    #   google-api-python-client
-    #   google-auth-httplib2
-humanize==0.5.1
-    # via -r requirements.in
-idna==2.8
-    # via requests
-itsdangerous==1.1.0
-    # via flask
-jinja2==2.11.3
-    # via flask
-loginpass==0.4
-    # via -r requirements.in
-mako==1.1.0
-    # via alembic
-markdown==3.1.1
-    # via -r requirements.in
-markupsafe==1.1.1
-    # via
-    #   jinja2
-    #   mako
-netaddr==0.7.19
-    # via -r requirements.in
-psycopg2==2.8.4
-    # via -r requirements.in
-pyasn1-modules==0.2.7
-    # via
-    #   -r requirements.in
-    #   google-auth
-pyasn1==0.4.8
-    # via
-    #   -r requirements.in
-    #   pyasn1-modules
-    #   rsa
-pycparser==2.19
-    # via cffi
-pymysql==0.9.3
-    # via -r requirements.in
-pyparsing==2.4.7
-    # via httplib2
-python-dateutil==2.8.1
-    # via
-    #   -r requirements.in
-    #   alembic
-python-editor==1.0.4
-    # via
-    #   -r requirements.in
-    #   alembic
-pytz==2019.3
-    # via
-    #   -r requirements.in
-    #   apscheduler
-    #   flask-restful
-    #   tzlocal
-redis==3.3.11
-    # via -r requirements.in
-requests==2.22.0
-    # via
-    #   -r requirements.in
-    #   loginpass
-rsa==4.0
-    # via google-auth
-sentry-sdk[flask]==0.14.3
-    # via -r requirements.in
-six==1.13.0
-    # via
-    #   apscheduler
-    #   cryptography
-    #   flask-cors
-    #   flask-restful
-    #   google-api-python-client
-    #   google-auth
-    #   python-dateutil
-    #   sqlalchemy-utils
-sqlalchemy-utils==0.36.0
-    # via -r requirements.in
-sqlalchemy==1.3.11
-    # via
-    #   -r requirements.in
-    #   alembic
-    #   flask-sqlalchemy
-    #   sqlalchemy-utils
-tzlocal==2.0.0
-    # via apscheduler
-unidecode==1.1.1
-    # via -r requirements.in
-uritemplate==3.0.0
-    # via google-api-python-client
-urllib3==1.25.8
-    # via
-    #   requests
-    #   sentry-sdk
-werkzeug==0.16.0
-    # via flask
-wtforms==2.2.1
-    # via flask-wtf
+alembic==1.6.2            # via flask-migrate
+aniso8601==9.0.1          # via flask-restful
+apscheduler==3.7.0        # via -r requirements.in
+authlib==0.15.3           # via -r requirements.in, loginpass
+blinker==1.4              # via sentry-sdk
+cachetools==4.2.2         # via google-auth
+certifi==2020.12.5        # via requests, sentry-sdk
+cffi==1.14.5              # via cryptography
+chardet==4.0.0            # via requests
+click==7.1.2              # via -r requirements.in, flask
+cryptography==3.4.7       # via authlib
+dnspython==2.1.0          # via email-validator
+email-validator==1.1.2    # via -r requirements.in
+flask-caching==1.10.1     # via -r requirements.in
+flask-cors==3.0.10        # via -r requirements.in
+flask-migrate==2.7.0      # via -r requirements.in
+flask-restful==0.3.8      # via -r requirements.in
+flask-sqlalchemy==2.5.1   # via -r requirements.in, flask-migrate
+flask-wtf==0.14.3         # via -r requirements.in
+flask==1.1.2              # via -r requirements.in, flask-caching, flask-cors, flask-migrate, flask-restful, flask-sqlalchemy, flask-wtf, sentry-sdk
+google-api-core==1.26.3   # via google-api-python-client
+google-api-python-client==2.3.0  # via -r requirements.in
+google-auth-httplib2==0.1.0  # via google-api-python-client
+google-auth==1.30.0       # via google-api-core, google-api-python-client, google-auth-httplib2
+googleapis-common-protos==1.53.0  # via google-api-core
+greenlet==1.1.0           # via sqlalchemy
+httplib2==0.19.1          # via google-api-python-client, google-auth-httplib2
+humanize==3.5.0           # via -r requirements.in
+idna==2.10                # via email-validator, requests
+itsdangerous==1.1.0       # via flask, flask-wtf
+jinja2==2.11.3            # via flask
+loginpass==0.5            # via -r requirements.in
+mako==1.1.4               # via alembic
+markdown==3.3.4           # via -r requirements.in
+markupsafe==1.1.1         # via jinja2, mako, wtforms
+netaddr==0.8.0            # via -r requirements.in
+packaging==20.9           # via google-api-core
+protobuf==3.16.0          # via google-api-core, googleapis-common-protos
+psycopg2==2.8.6           # via -r requirements.in
+pyasn1-modules==0.2.8     # via -r requirements.in, google-auth
+pyasn1==0.4.8             # via -r requirements.in, pyasn1-modules, rsa
+pycparser==2.20           # via cffi
+pymysql==1.0.2            # via -r requirements.in
+pyparsing==2.4.7          # via httplib2, packaging
+python-dateutil==2.8.1    # via -r requirements.in, alembic
+python-editor==1.0.4      # via -r requirements.in, alembic
+pytz==2021.1              # via -r requirements.in, apscheduler, flask-restful, google-api-core, tzlocal
+redis==3.5.3              # via -r requirements.in
+requests==2.25.1          # via -r requirements.in, google-api-core, loginpass
+rsa==4.7.2                # via google-auth
+sentry-sdk[flask]==1.1.0  # via -r requirements.in
+six==1.16.0               # via apscheduler, flask-cors, flask-restful, google-api-core, google-api-python-client, google-auth, google-auth-httplib2, protobuf, python-dateutil, sqlalchemy-utils
+sqlalchemy-utils==0.37.2  # via -r requirements.in
+sqlalchemy==1.4.14        # via -r requirements.in, alembic, flask-sqlalchemy, sqlalchemy-utils
+tzlocal==2.1              # via apscheduler
+unidecode==1.2.0          # via -r requirements.in
+uritemplate==3.0.1        # via google-api-python-client
+urllib3==1.26.4           # via requests, sentry-sdk
+werkzeug==1.0.1           # via flask
+wtforms==2.3.3            # via flask-wtf
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/trackman/__init__.py
+++ b/trackman/__init__.py
@@ -159,11 +159,11 @@ def init_app():
     cache_redis_url = app.config.get('CACHE_REDIS_URL',
                                      app.config['REDIS_URL'])
     playlists_cache.init_app(app, config={
-        'CACHE_TYPE': "redis",
+        'CACHE_TYPE': "RedisCache",
         'CACHE_REDIS_URL': cache_redis_url,
     })
     charts_cache.init_app(app, config={
-        'CACHE_TYPE': "redis",
+        'CACHE_TYPE': "RedisCache",
         'CACHE_REDIS_URL': cache_redis_url,
     })
 

--- a/trackman/auth/oidc.py
+++ b/trackman/auth/oidc.py
@@ -1,5 +1,5 @@
-from authlib.client import OAuthClient
 from authlib.jose import jwt, jwk
+from authlib.oauth2.client import OAuth2Client
 from authlib.oidc.core import CodeIDToken, ImplicitIDToken, UserInfo
 from flask import abort, current_app, json
 from .models import User
@@ -24,7 +24,7 @@ def create_oidc_backend(name, client_secrets_file=None, scopes=None):
     }
     issuer_url = client_secrets['web']['issuer']
 
-    class OpenIDConnectBackend(OAuthClient):
+    class OpenIDConnectBackend(OAuth2Client):
         OAUTH_TYPE = '2.0,oidc'
         OAUTH_NAME = name
         OAUTH_CONFIG = config

--- a/trackman/cache.py
+++ b/trackman/cache.py
@@ -4,7 +4,7 @@
 #   Copyright (c) 2016 by Peter Justin.
 
 from collections import OrderedDict
-from flask_caching import Cache, get_arg_names, get_arg_default, iteritems, \
+from flask_caching import Cache, get_arg_names, get_arg_default, \
     function_namespace
 
 
@@ -88,5 +88,5 @@ class ResourceCache(Cache):
             new_args.append(arg)
 
         return tuple(new_args), OrderedDict(sorted(
-            (k, v) for k, v in iteritems(kwargs) if k in kw_keys_remaining
+            (k, v) for k, v in kwargs.items() if k in kw_keys_remaining
         ))


### PR DESCRIPTION
* Update loginpass usage to match latest version
* Flask-Caching removed iteritems, so just use .items()

**Important Note:** Loginpass has changed the redirect_uri format; the
allowed redirect URLs must be updated at the appropriate identity
provider.