### PR TITLE
Show newest djsets first

### DIFF
--- a/trackman/api/v1/playlists.py
+++ b/trackman/api/v1/playlists.py
@@ -198,7 +198,7 @@ class PlaylistsByDJ(PlaylistResource):
         """
         dj = DJ.query.get_or_404(dj_id)
         sets = DJSet.query.filter(DJSet.dj_id == dj_id).order_by(
-            DJSet.dtstart).all()
+            DJSet.dtstart.desc()).all()
         return {
             'dj': dj.serialize(),
             'sets': [s.serialize() for s in sets],


### PR DESCRIPTION
https://github.com/wuvt/wuvt-site/issues/384


I'm still working on getting the whole local docker ecosystem up, so I have yet to test this fix.

The docs look like `desc()` should work without the import from sqlalchemy though:
https://docs.sqlalchemy.org/en/14/core/sqlelement.html#sqlalchemy.sql.expression.desc

and it appears to be in use in `api/v1/charts.py` and `lib.py` already.