### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish to GitHub Package Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: wuvt/trackman
         username: wuvt

--- a/.github/workflows/nginx-docker.yml
+++ b/.github/workflows/nginx-docker.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish to GitHub Package Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: wuvt/trackman-nginx
         username: wuvt


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore