### PR TITLE
Update nchan container

### DIFF
--- a/.github/workflows/nginx-docker.yml
+++ b/.github/workflows/nginx-docker.yml
@@ -8,6 +8,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: Publish to GitHub Package Registry
       uses: elgohr/Publish-Docker-Github-Action@master
+      env:
+        DOCKER_BUILDKIT: "1"
       with:
         name: wuvt/trackman-nginx
         username: wuvt

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,3 +1,24 @@
-FROM meroje/alpine-nchan:1.1.15
+FROM debian:11-slim as builder
+# following on the approach described in
+# https://github.com/GoogleContainerTools/distroless/issues/863#issuecomment-949723748
+RUN cd /tmp && \
+    apt-get update && \
+    apt-get download iproute2 debconf perl-base libcrypt1 libbpf0 libelf1 \
+        zlib1g libbsd0 libmd0 libcap2 libcap2-bin libdb5.3 libmnl0 \
+        libselinux1 libpcre2-8-0 libxtables12 libnginx-mod-http-echo \
+        nginx-common lsb-base libpcre3 nginx-light libnginx-mod-nchan && \
+    mkdir /dpkg && \
+    for deb in *.deb; do dpkg --extract $deb /dpkg; done
+
+FROM gcr.io/distroless/base-debian11:nonroot
+USER root
+COPY --from=builder /dpkg /
+RUN --mount=type=bind,from=builder,target=/mnt ["/mnt/bin/ln", "-sf", "/dev/stdout", "/var/log/nginx/access.log"]
+RUN --mount=type=bind,from=builder,target=/mnt ["/mnt/bin/ln", "-sf", "/dev/stderr", "/var/log/nginx/error.log"]
+
 COPY nginx/nginx.conf /etc/nginx/nginx.conf
 COPY trackman/static /srv/http/static
+
+EXPOSE 80
+
+CMD ["/usr/sbin/nginx", "-g", "daemon off;"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,16 +1,17 @@
-FROM debian:11-slim as builder
+FROM debian:12-slim as builder
 # following on the approach described in
 # https://github.com/GoogleContainerTools/distroless/issues/863#issuecomment-949723748
 RUN cd /tmp && \
     apt-get update && \
-    apt-get download iproute2 debconf perl-base libcrypt1 libbpf0 libelf1 \
-        zlib1g libbsd0 libmd0 libcap2 libcap2-bin libdb5.3 libmnl0 \
-        libselinux1 libpcre2-8-0 libxtables12 libnginx-mod-http-echo \
-        nginx-common lsb-base libpcre3 nginx-light libnginx-mod-nchan && \
+    apt-get download  debconf zlib1g libelf1 libbpf1 libmd0 libbsd0 libcap2 \
+        libcap2-bin libdb5.3 libmnl0 libpcre2-8-0 libselinux1 libcom-err2 \
+        libkrb5support0 libk5crypto3 libkeyutils1 libkrb5-3 libgssapi-krb5-2 \
+        libtirpc-common libtirpc3 libxtables12 iproute2 libcrypt1 nginx-common \
+        nginx libnginx-mod-http-echo nginx-light libnginx-mod-nchan && \
     mkdir /dpkg && \
     for deb in *.deb; do dpkg --extract $deb /dpkg; done
 
-FROM gcr.io/distroless/base-debian11:nonroot
+FROM gcr.io/distroless/base-debian12:nonroot
 USER root
 COPY --from=builder /dpkg /
 RUN --mount=type=bind,from=builder,target=/mnt ["/mnt/bin/ln", "-sf", "/dev/stdout", "/var/log/nginx/access.log"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,5 @@
 
-user  nginx;
+user  nobody;
 worker_processes  1;
 
 error_log  /var/log/nginx/error.log warn;


### PR DESCRIPTION
While bringing up the old cluster on our new network, I learned Alpine and Kubernetes DNS don't exactly get along. Perfect excuse to update the 5 year old nginx container! Couldn't find an nchan container image I was happy with so I whipped up a quick one based on [distroless](https://github.com/GoogleContainerTools/distroless).